### PR TITLE
FEAT: model.generate argument 추가 및 input max length 변경

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def generate_summary(dialogue:str):
         dialogue,
         padding="max_length",
         truncation=True,
-        max_length=128,
+        max_length=512,
         return_tensors="pt",
     )
 
@@ -58,6 +58,8 @@ def generate_summary(dialogue:str):
                              attention_mask=attention_mask,
                              top_k=50,
                              top_p=0.95,
+                             no_repeat_ngram_size=3,
+                             temperature=0.7
                              )
 
     output_str = tokenizer.batch_decode(outputs, skip_special_tokens=True)


### PR DESCRIPTION
no_repeat_ngram_size=3, temperature=0.7
- argument로 전달시 성능 향상

tokenizer의 max_length 512로 변경
- 기존 128로 진행시 dialogue 과도하게 짧아짐